### PR TITLE
Fix broken pippipe

### DIFF
--- a/pippipe.rb
+++ b/pippipe.rb
@@ -4,11 +4,11 @@ require_relative 'pipboy/message'
 STDOUT.sync = true
 ip = ARGV[0]
 socket = TCPSocket.new(ip, 27000)
-keep_alive_msg = Pipboy::Message.keep_alive.to_bytes
+keep_alive = "\x00\x00\x00\x00\x00"
 
 while line = socket.recv(8)
-  if line == keep_alive_msg
-    socket.send(keep_alive_msg, 0)
+  if line == keep_alive
+    socket.send(keep_alive, 0)
   end
   n = STDOUT.write(line)
 end


### PR DESCRIPTION
@Bontgoy — you're right, I just straight up broke pippipe (wasn't using it since I was home away from my PS4).

In removing the Message class I also removed any abstraction that made _new_ messages. Since that's gone, I've just replaced it with the hardcoded sequence of five 00s until we write something that knows how to make new messages for us.

The bit in MessageReaders doesn't actually make a keep alive message, it just parses an incoming keep alive from the server, that's why your other PR won't work.

It that makes sense, why don't you merge this one in (make sure you hit delete branch afterwards)
